### PR TITLE
feat: replace ad-hoc stream merging with redirect-to-output pattern

### DIFF
--- a/Public/Invoke-HandleRequest.ps1
+++ b/Public/Invoke-HandleRequest.ps1
@@ -44,33 +44,107 @@ function Invoke-HandleRequest {
         $toolName = $request.params.name
         $targetArgs = $request.params.arguments | ConvertTo-Json -Depth 10 | ConvertFrom-Json -Depth 10 -AsHashtable
 
-        $result = & $toolName @targetArgs
+        try {
+            # Redirect all streams (Error=2, Warning=3, Verbose=4, Debug=5, Information=6) to the
+            # output stream so they arrive in chronological order and can be logged by type
+            $rawOutput = & $toolName @targetArgs 2>&1 3>&1 4>&1 5>&1 6>&1
 
-        # Log structured data
-        Write-Log -LogEntry @{
-            RequestId = $request.id
-            Method    = $request.method
-            ToolName  = $toolName
-            Arguments = $targetArgs
-            Result    = $result
-            # FullRequest = $request # Optionally include the full request if needed, can be large
-        }
+            # Walk output in order — log stream records, collect actual output
+            $actualOutput = [System.Collections.Generic.List[object]]::new()
+            $hadErrors = $false
 
-        $response = [ordered]@{
-            jsonrpc = "2.0"
-            id      = $request.id
-            result  = @{
-                content = @(
-                    [ordered]@{
-                        type = "text"
-                        text = $result | Out-String
+            foreach ($item in $rawOutput) {
+                $level = $null
+                $stream = $null
+                $extra = @{}
+
+                switch ($item) {
+                    { $_.GetType().FullName -notmatch '^System\.Management\.Automation\.(Error|Warning|Verbose|Debug|Information)Record$' } {
+                        $actualOutput.Add($item); break
                     }
-                )
-                isError = $false
-            }
-        }
+                    { $_ -is [System.Management.Automation.ErrorRecord] } {
+                        $hadErrors = $true
+                        $level = 'Error'
+                        $stream = 'Error'
+                        $extra = @{ Category = $item.CategoryInfo.ToString() }
+                        break
+                    }
+                    { $_ -is [System.Management.Automation.WarningRecord] } { $level = 'Warn'; $stream = 'Warning'; break }
+                    { $_ -is [System.Management.Automation.VerboseRecord] } { $level = 'Verbose'; $stream = 'Verbose'; break }
+                    { $_ -is [System.Management.Automation.DebugRecord] } { $level = 'Debug'; $stream = 'Debug'; break }
+                    { $_ -is [System.Management.Automation.InformationRecord] } {
+                        $level = 'Info'
+                        $stream = 'Information'
+                        $extra = @{ Tags = ($item.Tags -join ',') }
+                        break
+                    }
+                }
 
-        return ($response | ConvertTo-Json -Depth 10 -Compress)
+                if ($level) {
+                    Write-Log -LogEntry (@{
+                            Level    = $level
+                            Message  = $item.ToString()
+                            ToolName = $toolName
+                            Stream   = $stream
+                        } + $extra)
+                }
+            }
+
+            Write-Log -LogEntry @{
+                Level     = 'Info'
+                RequestId = $request.id
+                Method    = $request.method
+                ToolName  = $toolName
+                Arguments = $targetArgs
+                Result    = ($actualOutput | Out-String)
+            }
+
+            $response = [ordered]@{
+                jsonrpc = "2.0"
+                id      = $request.id
+                result  = @{
+                    content = @(
+                        [ordered]@{
+                            type = "text"
+                            text = if ($hadErrors) {
+                                ($rawOutput | Where-Object { $_ -is [System.Management.Automation.ErrorRecord] } | ForEach-Object { $_.ToString() }) -join "`n"
+                            }
+                            else {
+                                $actualOutput | Out-String
+                            }
+                        }
+                    )
+                    isError = $hadErrors
+                }
+            }
+
+            return ($response | ConvertTo-Json -Depth 10 -Compress)
+        }
+        catch {
+            Write-Log -LogEntry @{
+                Level     = 'Error'
+                Message   = $_.Exception.Message
+                ToolName  = $toolName
+                Stream    = 'Exception'
+                Exception = $_.ToString()
+            }
+
+            $response = [ordered]@{
+                jsonrpc = "2.0"
+                id      = $request.id
+                result  = @{
+                    content = @(
+                        [ordered]@{
+                            type = "text"
+                            text = $_.Exception.Message
+                        }
+                    )
+                    isError = $true
+                }
+            }
+
+            return ($response | ConvertTo-Json -Depth 10 -Compress)
+        }
     }
 
     # Unknown Method Error

--- a/__tests__/Invoke-HandleRequest.Tests.ps1
+++ b/__tests__/Invoke-HandleRequest.Tests.ps1
@@ -1,0 +1,134 @@
+Describe 'Invoke-HandleRequest tools/call with PowerShell.Create' {
+    BeforeAll {
+        Import-Module $PSScriptRoot\..\PSMCP.psd1 -Force
+        Set-LogFile TestDrive:\mcp_server.log
+        . $PSScriptRoot/sampleFunctions/Invoke-StreamTest.ps1
+        $toolsListJson = Register-MCPTool -FunctionName Invoke-StreamTest
+    }
+
+    AfterAll {
+        Remove-Item -Recurse -Force TestDrive:\ -ErrorAction SilentlyContinue
+    }
+
+    It 'Should capture normal output as text content' {
+        $request = @{
+            jsonrpc = '2.0'
+            id      = 1
+            method  = 'tools/call'
+            params  = @{ name = 'Invoke-StreamTest'; arguments = @{ Action = 'normal' } }
+        }
+        $response = Invoke-HandleRequest -request $request -toolsListJson $toolsListJson | ConvertFrom-Json
+        $response.result.content[0].text.Trim() | Should -Be 'Normal output'
+        $response.result.isError | Should -BeFalse
+    }
+
+    It 'Should set isError true when tool writes to error stream' {
+        $request = @{
+            jsonrpc = '2.0'
+            id      = 2
+            method  = 'tools/call'
+            params  = @{ name = 'Invoke-StreamTest'; arguments = @{ Action = 'error' } }
+        }
+        $response = Invoke-HandleRequest -request $request -toolsListJson $toolsListJson | ConvertFrom-Json
+        $response.result.isError | Should -BeTrue
+    }
+
+    It 'Should include error message in text when tool writes to error stream' {
+        $request = @{
+            jsonrpc = '2.0'
+            id      = 3
+            method  = 'tools/call'
+            params  = @{ name = 'Invoke-StreamTest'; arguments = @{ Action = 'error' } }
+        }
+        $response = Invoke-HandleRequest -request $request -toolsListJson $toolsListJson | ConvertFrom-Json
+        $response.result.content[0].text | Should -BeLike '*Test error message*'
+    }
+
+    It 'Should set isError true when tool throws a terminating error' {
+        $request = @{
+            jsonrpc = '2.0'
+            id      = 4
+            method  = 'tools/call'
+            params  = @{ name = 'Invoke-StreamTest'; arguments = @{ Action = 'throw' } }
+        }
+        $response = Invoke-HandleRequest -request $request -toolsListJson $toolsListJson | ConvertFrom-Json
+        $response.result.isError | Should -BeTrue
+        $response.result.content[0].text | Should -BeLike '*Test terminating error*'
+    }
+
+    It 'Should log warning stream records with Level Warn' {
+        $logFile = 'TestDrive:\mcp_server.log'
+        Set-Content -Path $logFile -Value ''
+        $request = @{
+            jsonrpc = '2.0'
+            id      = 5
+            method  = 'tools/call'
+            params  = @{ name = 'Invoke-StreamTest'; arguments = @{ Action = 'warning' } }
+        }
+        $null = Invoke-HandleRequest -request $request -toolsListJson $toolsListJson
+        $logContent = Get-Content $logFile | Where-Object { $_ } | ForEach-Object { ConvertFrom-Json -InputObject:$_ }
+        $warnEntry = $logContent | Where-Object { $_.Level -eq 'Warn' -and $_.Stream -eq 'Warning' }
+        $warnEntry | Should -Not -BeNullOrEmpty
+        $warnEntry.Message | Should -BeLike '*Test warning message*'
+    }
+
+    It 'Should still return output when tool also writes warnings' {
+        $request = @{
+            jsonrpc = '2.0'
+            id      = 6
+            method  = 'tools/call'
+            params  = @{ name = 'Invoke-StreamTest'; arguments = @{ Action = 'warning' } }
+        }
+        $response = Invoke-HandleRequest -request $request -toolsListJson $toolsListJson | ConvertFrom-Json
+        $response.result.content[0].text.Trim() | Should -Be 'output after warning'
+        $response.result.isError | Should -BeFalse
+    }
+
+    It 'Should log error stream records with Level Error' {
+        $logFile = 'TestDrive:\mcp_server.log'
+        Set-Content -Path $logFile -Value ''
+        $request = @{
+            jsonrpc = '2.0'
+            id      = 7
+            method  = 'tools/call'
+            params  = @{ name = 'Invoke-StreamTest'; arguments = @{ Action = 'error' } }
+        }
+        $null = Invoke-HandleRequest -request $request -toolsListJson $toolsListJson
+        $logContent = Get-Content $logFile | Where-Object { $_ } | ForEach-Object { ConvertFrom-Json -InputObject:$_ }
+        $errorEntry = $logContent | Where-Object { $_.Level -eq 'Error' -and $_.Stream -eq 'Error' }
+        $errorEntry | Should -Not -BeNullOrEmpty
+        $errorEntry.Message | Should -BeLike '*Test error message*'
+    }
+
+    It 'Should log terminating errors with Level Error and Stream Exception' {
+        $logFile = 'TestDrive:\mcp_server.log'
+        Set-Content -Path $logFile -Value ''
+        $request = @{
+            jsonrpc = '2.0'
+            id      = 8
+            method  = 'tools/call'
+            params  = @{ name = 'Invoke-StreamTest'; arguments = @{ Action = 'throw' } }
+        }
+        $null = Invoke-HandleRequest -request $request -toolsListJson $toolsListJson
+        $logContent = Get-Content $logFile | ConvertFrom-Json
+        $exceptionEntry = $logContent | Where-Object { $_.Level -eq 'Error' -and $_.Stream -eq 'Exception' }
+        $exceptionEntry | Should -Not -BeNullOrEmpty
+        $exceptionEntry.Message | Should -BeLike '*Test terminating error*'
+    }
+
+    It 'Should log verbose stream records with Level Verbose' {
+        $logFile = 'TestDrive:\mcp_server.log'
+        Set-Content -Path $logFile -Value ''
+        $request = @{
+            jsonrpc = '2.0'
+            id      = 9
+            method  = 'tools/call'
+            params  = @{ name = 'Invoke-StreamTest'; arguments = @{ Action = 'verbose'; Verbose = $true } }
+        }
+        $null = Invoke-HandleRequest -request $request -toolsListJson $toolsListJson
+        $logContent = Get-Content $logFile | Where-Object { $_ } | ForEach-Object { ConvertFrom-Json -InputObject:$_ }
+        $verboseEntry = $logContent | Where-Object { $_.Level -eq 'Verbose' -and $_.Stream -eq 'Verbose' }
+        $verboseEntry | Should -Not -BeNullOrEmpty
+        $verboseEntry.Message | Should -BeLike '*Test verbose message*'
+    }
+}

--- a/__tests__/sampleFunctions/Invoke-StreamTest.ps1
+++ b/__tests__/sampleFunctions/Invoke-StreamTest.ps1
@@ -1,0 +1,17 @@
+function Global:Invoke-StreamTest {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Action
+    )
+
+    switch ($Action) {
+        'warning' { Write-Warning "Test warning message"; "output after warning" }
+        'error'   { Write-Error "Test error message" }
+        'verbose' { Write-Verbose "Test verbose message" -Verbose; "output after verbose" }
+        'debug'   { Write-Debug "Test debug message" -Debug; "output after debug" }
+        'info'    { Write-Information "Test information message" -InformationAction Continue; "output after info" }
+        'throw'   { throw "Test terminating error" }
+        'normal'  { "Normal output" }
+    }
+}


### PR DESCRIPTION
Use `& $toolName @targetArgs 2>&1 3>&1 4>&1 5>&1 6>&1` to capture all PS streams in chronological order

Walk output once: fast-path non-stream objects to actualOutput, log

ErrorRecord/WarningRecord/VerboseRecord/DebugRecord/InformationRecord

with appropriate level via Write-Log

Set `$hadErrors` from ErrorRecord presence; surfaces as isError in MCP response

Add Invoke-StreamTest sample function and Pester tests